### PR TITLE
Add Gujarati practice view

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ The application uses a couple of add-ons:
  * Vaadin Charts, AGPL/CVAL: https://vaadin.com/license/cval-2.0
  * Vaadin Calendar, Apache 2.0
  * CSSInject, Apache 2.0
+
+Gujarati practice
+-----------------
+After signing in, a new **Gujarati** view is available from the sidebar. It contains a few common phrases and uses the browser's speech synthesis to pronounce them in Gujarati when you click the buttons.

--- a/src/main/java/com/vaadin/demo/dashboard/DashboardUI.java
+++ b/src/main/java/com/vaadin/demo/dashboard/DashboardUI.java
@@ -77,6 +77,7 @@ public class DashboardUI extends UI {
             put("/transactions", TransactionsView.class);
             put("/reports", ReportsView.class);
             put("/schedule", ScheduleView.class);
+            put("/gujarati", GujaratiView.class);
         }
     };
 
@@ -316,7 +317,7 @@ public class DashboardUI extends UI {
         menu.removeAllComponents();
 
         for (final String view : new String[] { "dashboard", "sales",
-                "transactions", "reports", "schedule" }) {
+                "transactions", "reports", "schedule", "gujarati" }) {
             Button b = new NativeButton(view.substring(0, 1).toUpperCase()
                     + view.substring(1).replace('-', ' '));
             b.addStyleName("icon-" + view);

--- a/src/main/java/com/vaadin/demo/dashboard/GujaratiView.java
+++ b/src/main/java/com/vaadin/demo/dashboard/GujaratiView.java
@@ -1,0 +1,42 @@
+package com.vaadin.demo.dashboard;
+
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
+import com.vaadin.server.Page;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.VerticalLayout;
+
+/**
+ * Simple view to practice Gujarati phrases.
+ */
+public class GujaratiView extends VerticalLayout implements View {
+
+    public GujaratiView() {
+        setMargin(true);
+        setSpacing(true);
+
+        Label title = new Label("Gujarati Practice");
+        title.addStyleName("h1");
+        addComponent(title);
+
+        addPhrase("Hello", "નમસ્તે");
+        addPhrase("How are you?", "કેમ છો?");
+        addPhrase("Thank you", "આભાર");
+    }
+
+    private void addPhrase(String english, String gujarati) {
+        Button b = new Button(english + " - " + gujarati);
+        b.addClickListener(event -> {
+            String js = "var msg = new SpeechSynthesisUtterance('" + gujarati.replace("'", "\\'") + "');" +
+                    "msg.lang='gu-IN';window.speechSynthesis.speak(msg);";
+            Page.getCurrent().getJavaScript().execute(js);
+        });
+        addComponent(b);
+    }
+
+    @Override
+    public void enter(ViewChangeEvent event) {
+        // No actions needed on view change
+    }
+}


### PR DESCRIPTION
## Summary
- Add a simple Gujarati practice view with buttons that use browser speech synthesis to pronounce phrases.
- Register the new Gujarati view in the dashboard UI and sidebar menu.
- Document the Gujarati practice view in the README.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: com.vaadin.demo:demo:pom:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_689661de672c83339b5291c4b0f55135